### PR TITLE
K8S 1.22 Support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 
 kube_dns_kubeconfig: "~/.kube/config"
 kube_dns_state: "present"
-kube_dns_coredns_version: "1.3.1"
+kube_dns_coredns_version: "1.8.7"
 
 kubernetes_dns_service_ip: "10.0.8.8"
 kubernetes_cluster_domain: cluster.local

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,5 @@ kube_dns_coredns_version: "1.8.7"
 
 kubernetes_dns_service_ip: "10.0.8.8"
 kubernetes_cluster_domain: cluster.local
+
+kubernetes_manual_upstream_ips: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -129,6 +129,16 @@
           k8s-app: kube-dns
           kubernetes.io/name: "CoreDNS"
       spec:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                    - key: k8s-app
+                      operator: In
+                      values:
+                        - kube-dns
+                topologyKey: "kubernetes.io/hostname"
         replicas: 2
         strategy:
           type: RollingUpdate

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,6 +42,12 @@
           verbs:
             - list
             - watch
+        - apiGroups: [ "discovery.k8s.io" ]
+          resources:
+            - endpointslices
+          verbs:
+            - watch
+            - list
         - apiGroups:
             - ""
           resources:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 
 - name: Gather router facts
+  when: kubernetes_ansible_router_group is defined
   setup:
   delegate_to: "{{ item }}"
   delegate_facts: True
@@ -106,7 +107,11 @@
                 fallthrough in-addr.arpa ip6.arpa
               }
               prometheus :9153
+              {% if kubernetes_manual_upstream_ips == [] %}
               forward . {% for router in groups[kubernetes_ansible_router_group] %}{{ hostvars[router]['ansible_all_ipv4_addresses'] | ipaddr('private') | join(' ') }} {% endfor %}
+              {% else %}
+              forward . {% for upstream in kubernetes_manual_upstream_ips %}{{ upstream }} {% endfor %}
+              {% endif %}
 
               cache 30
               loop


### PR DESCRIPTION
This PR:
 * Adds support for K8S 1.22 (one API change and bump the default version)
 * Adds pod anti-affinity (to prevent pods getting put onto the same node)
 * Adds support for "router-less" setup where we have no dedicated router nodes
